### PR TITLE
Sabaj Da2, Da3 DSD support

### DIFF
--- a/sound/usb/quirks.c
+++ b/sound/usb/quirks.c
@@ -944,6 +944,7 @@ u64 snd_usb_interface_dsd_format_quirks(struct snd_usb_audio *chip,
 
 	/* XMOS based USB DACs */
 	switch (chip->usb_id) {
+	case USB_ID(0x152a, 0x85df): /* Sabaj Da2, Da3 */
 	case USB_ID(0x1511, 0x0037): /* AURALiC VEGA */
 	case USB_ID(0x20b1, 0x0002): /* Wyred 4 Sound DAC-2 DSD */
 	case USB_ID(0x20b1, 0x3008): /* iFi Audio micro/nano iDSD */


### PR DESCRIPTION
Add USB ID for Sabaj Da2, Da3, to enable native DSD modes:
http://www.sabaj.com.cn/en/products.asp