### PR TITLE
Native DSD | Matrix Audio X-SPDIF 2

### DIFF
--- a/sound/usb/quirks.c
+++ b/sound/usb/quirks.c
@@ -982,6 +982,7 @@ u64 snd_usb_interface_dsd_format_quirks(struct snd_usb_audio *chip,
 	case USB_ID(0x20b1, 0x3008): /* iFi Audio micro/nano iDSD */
 	case USB_ID(0x20b1, 0x2008): /* Matrix Audio X-Sabre */
 	case USB_ID(0x20b1, 0x300a): /* Matrix Audio Mini-i Pro */
+	case USB_ID(0x20b1, 0x2004): /* Matrix Audio X-SPDIF 2 */
 	case USB_ID(0x22d9, 0x0416): /* OPPO HA-1 */
 	case USB_ID(0x22d9, 0x0436): /* OPPO Sonica */
 	case USB_ID(0x22d9, 0x0461): /* OPPO UDP-205 */


### PR DESCRIPTION
Addition as requested by user: https://community.roonlabs.com/t/native-dsd256-not-working-with-ropieee-and-an-armature-hecate-interface/34653/9?u=dan_knight