### PR TITLE
Native DSD | Luxman DA-06

### DIFF
--- a/sound/usb/quirks.c
+++ b/sound/usb/quirks.c
@@ -978,6 +978,7 @@ u64 snd_usb_interface_dsd_format_quirks(struct snd_usb_audio *chip,
 	switch (chip->usb_id) {
 	case USB_ID(0x152a, 0x85df): /* Sabaj Da2, Da3 */
 	case USB_ID(0x1511, 0x0037): /* AURALiC VEGA */
+	case USB_ID(0x1852, 0x5065): /* Luxman DA-06 */
 	case USB_ID(0x20b1, 0x0002): /* Wyred 4 Sound DAC-2 DSD */
 	case USB_ID(0x20b1, 0x3008): /* iFi Audio micro/nano iDSD */
 	case USB_ID(0x20b1, 0x2008): /* Matrix Audio X-Sabre */


### PR DESCRIPTION
+ Derived from: https://github.com/torvalds/linux/commit/71426535f49fe6034d0e0db77608b91a0c1a022d#diff-d612132741334e301818d179e3667f40R1162
+ As per user request: https://dietpi.com/phpbb/viewtopic.php?p=17208#p17208

________
As can be seen there have been added a bunch of other sound devices for native DSD to the main kernel tree. I guess those could be added here as well?